### PR TITLE
ci: bump setup-android v3 -> v4

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -45,7 +45,7 @@ jobs:
           cache: 'gradle'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
       - name: List buildtools
         run: ls /usr/local/lib/android/sdk/build-tools/
 


### PR DESCRIPTION
Bumps `android-actions/setup-android` v3 → v4. v3 targets deprecated Node 20 (CI warning, forced onto Node 24); v4 runs Node 24 natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THQcNEXLkSViHX8JUW2Yjn